### PR TITLE
Use BuildKit secret for npm token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
+# syntax=docker/dockerfile:1.4
 FROM node:20-alpine
 
 WORKDIR /app
 
-ARG NPM_TOKEN
-COPY .npmrc .npmrc
-
 COPY package.json ./
 COPY package-lock.json ./
+COPY .npmrc .npmrc
 
-RUN npm install && rm -f .npmrc
+RUN --mount=type=secret,id=npm_token \
+    NPM_TOKEN=$(cat /run/secrets/npm_token) && \
+    npm install && rm -f .npmrc
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ Para obtener una licencia comercial o consultar sobre colaboración, escríbenos
 
 ## 🚀 Construcción del contenedor
 
-Para instalar las dependencias privadas durante el build se utiliza un fichero `.npmrc` que requiere un token de autenticación.
+Para instalar las dependencias privadas durante el build se utiliza un fichero `.npmrc` que requiere un token de autenticación. Es recomendable usar [Docker BuildKit](https://docs.docker.com/build/) para pasar el token como un *secret* y evitar que quede almacenado en la imagen.
 
-1. Defina la variable `NPM_TOKEN` con un token válido para el registro `npm.pkg.github.com`.
-2. Al construir la imagen con Docker o `docker-compose` se pasará este token como argumento de construcción.
+1. Cree un token personal con permiso `read:packages` y defina la variable de entorno `NPM_TOKEN`.
+2. Ejecute la construcción indicando el secreto:
 
 ```bash
-NPM_TOKEN=xxxxxxxx docker compose build
+NPM_TOKEN=xxxxxxxx docker compose build --secret id=npm_token,env=NPM_TOKEN
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        NPM_TOKEN: ${NPM_TOKEN}
+      secrets:
+        - npm_token
     ports:
       - "3000:3000"
     environment:
@@ -16,5 +16,9 @@ services:
       - GHL_CONVERSATION_PROVIDER_ID=${GHL_CONVERSATION_PROVIDER_ID}
       - APP_URL=${APP_URL}
       - GHL_SHARED_SECRET=${GHL_SHARED_SECRET}
-    command: sh -c "npx prisma migrate deploy && npm run build && npm run start:prod"
-    restart: unless-stopped
+  command: sh -c "npx prisma migrate deploy && npm run build && npm run start:prod"
+  restart: unless-stopped
+
+secrets:
+  npm_token:
+    environment: NPM_TOKEN


### PR DESCRIPTION
## Summary
- secure npm install using Docker BuildKit secret
- document BuildKit usage for the npm token
- update docker-compose to pass the secret

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871dd5a9760832298cb8c892bead358