### PR TITLE
Revert schema change and expand docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Este repositorio es de uso interno. Ninguna parte de este código puede ser copi
 
 Para obtener una licencia comercial o consultar sobre colaboración, escríbenos a: `tucorreo@tudominio.com`.
 
+## 🔁 Sincronización de conversaciones
+WLink Bridge mantiene un único hilo por cliente en GoHighLevel donde se integran todos los mensajes de WhatsApp. Cada location puede gestionar varios números a la vez y distinguirlos por su avatar.
+
+## 💳 Suscripciones flexibles
+Las instancias se contratan por periodos mensuales o mayores. El administrador define precios y descuentos y el pago se realiza con PayPal. Al expirar la suscripción las instancias se desactivan hasta renovarla.
+
 ---
 
 ## 🛠 Estado del desarrollo


### PR DESCRIPTION
## Summary
- revert `schema.prisma` back to the original PostgreSQL models
- document conversation sync and subscription model in README

## Testing
- `npm run build` *(fails: cannot compile due to missing Prisma client binaries)*

------
https://chatgpt.com/codex/tasks/task_e_6871e7974a9c832283a0157f8f84e64b