### PR TITLE
Fix env URL validation and docs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -63,3 +63,7 @@ Si no cuenta con acceso a los paquetes privados, puede omitir la variable NPM_TO
 
 Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 antes de ejecutar npx prisma generate para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y defina la variable `DATABASE_URL` con su cadena de conexión de PostgreSQL.
+La URL debe comenzar con `postgresql://` o `postgres://` conforme a la [documentación de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). Ajuste también el resto de variables siguiendo sus credenciales de GoHighLevel y Evolution API.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ dependencias públicas.
 
 ### Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` antes de ejecutar `npx prisma generate` para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y ajuste la variable `DATABASE_URL` con la cadena de conexión de PostgreSQL.
+La URL debe comenzar con `postgresql://` o `postgres://` según la [documentación oficial de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). También actualice el resto de variables de acuerdo con su cuenta de GoHighLevel y Evolution API.

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -26,6 +26,14 @@ export class PrismaService
   private readonly logger = new Logger(PrismaService.name);
 
   async onModuleInit() {
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      this.logger.error(
+        'Invalid DATABASE_URL. It must start with "postgresql://" or "postgres://"',
+      );
+      throw new Error('Invalid DATABASE_URL');
+    }
+
     const retries = parseInt(process.env.DB_CONNECT_RETRIES || '5', 10);
     const delayMs = parseInt(process.env.DB_CONNECT_DELAY_MS || '2000', 10);
 


### PR DESCRIPTION
## Summary
- check that `DATABASE_URL` uses `postgres://` or `postgresql://` before connecting
- document how to create a `.env` file with proper database URL

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872b45c764c8322a93310f5a14afe22