### PR TITLE
Fix env URL validation and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Example environment configuration for WLink Bridge
-DATABASE_URL="postgresql://user:password@localhost:5432/adapter"
+# The DATABASE_URL should not be quoted when used with docker-compose
+DATABASE_URL=postgresql://user:password@localhost:5432/adapter
 GHL_CLIENT_ID="YOUR_CLIENT_ID"
 GHL_CLIENT_SECRET="YOUR_CLIENT_SECRET"
 GHL_CONVERSATION_PROVIDER_ID="YOUR_CONVERSATION_PROVIDER_ID"

--- a/README.es.md
+++ b/README.es.md
@@ -63,3 +63,8 @@ Si no cuenta con acceso a los paquetes privados, puede omitir la variable NPM_TO
 
 Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 antes de ejecutar npx prisma generate para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y defina la variable `DATABASE_URL` con su cadena de conexión de PostgreSQL.
+Si usa `docker-compose`, evite poner comillas alrededor de la URL para que la variable se expanda correctamente.
+La URL debe comenzar con `postgresql://` o `postgres://` conforme a la [documentación de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). Ajuste también el resto de variables siguiendo sus credenciales de GoHighLevel y Evolution API.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ dependencias públicas.
 
 ### Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` antes de ejecutar `npx prisma generate` para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y ajuste la variable `DATABASE_URL` con la cadena de conexión de PostgreSQL.
+Si utiliza `docker-compose`, no agregue comillas alrededor de la URL para evitar que se pasen al contenedor.
+La URL debe comenzar con `postgresql://` o `postgres://` según la [documentación oficial de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). También actualice el resto de variables de acuerdo con su cuenta de GoHighLevel y Evolution API.

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -25,6 +25,24 @@ export class PrismaService
     > {
   private readonly logger = new Logger(PrismaService.name);
 
+  constructor() {
+    const rawUrl = process.env.DATABASE_URL || '';
+    let dbUrl = rawUrl.trim();
+    if (dbUrl.startsWith('"') && dbUrl.endsWith('"')) {
+      dbUrl = dbUrl.slice(1, -1);
+      process.env.DATABASE_URL = dbUrl;
+    }
+
+    if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      // Throw early before PrismaClient tries to read the schema
+      throw new Error(
+        'Invalid DATABASE_URL. It must start with "postgresql://" or "postgres://"',
+      );
+    }
+
+    super();
+  }
+
   async onModuleInit() {
     const retries = parseInt(process.env.DB_CONNECT_RETRIES || '5', 10);
     const delayMs = parseInt(process.env.DB_CONNECT_DELAY_MS || '2000', 10);


### PR DESCRIPTION
## Summary
- normalize quoted `DATABASE_URL` when PrismaService starts
- remove quotes from `.env.example`
- clarify environment variable instructions in README files

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b45c764c8322a93310f5a14afe22