### PR TITLE
Add Evolution API auth flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
 # Example environment configuration for WLink Bridge
-DATABASE_URL="postgresql://user:password@localhost:5432/adapter"
+# The DATABASE_URL should not be quoted when used with docker-compose
+DATABASE_URL=postgresql://user:password@localhost:5432/adapter
 GHL_CLIENT_ID="YOUR_CLIENT_ID"
 GHL_CLIENT_SECRET="YOUR_CLIENT_SECRET"
 GHL_CONVERSATION_PROVIDER_ID="YOUR_CONVERSATION_PROVIDER_ID"
 APP_URL=https://your-adapter-domain.com
 GHL_SHARED_SECRET="YOUR_SHARED_SECRET"
+EVOLUTION_API_URL=https://your-evolution-api.com
 NPM_TOKEN="YOUR_NPM_TOKEN"
 DB_CONNECT_RETRIES=5
 DB_CONNECT_DELAY_MS=2000

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 .idea
+
+tsconfig.build.tsbuildinfo

--- a/README.es.md
+++ b/README.es.md
@@ -63,3 +63,8 @@ Si no cuenta con acceso a los paquetes privados, puede omitir la variable NPM_TO
 
 Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 antes de ejecutar npx prisma generate para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y defina la variable `DATABASE_URL` con su cadena de conexión de PostgreSQL.
+Si usa `docker-compose`, evite poner comillas alrededor de la URL para que la variable se expanda correctamente.
+La URL debe comenzar con `postgresql://` o `postgres://` conforme a la [documentación de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). Además configure `EVOLUTION_API_URL` con la ruta base de Evolution API v2 y ajuste las demás variables siguiendo sus credenciales de GoHighLevel y Evolution API.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ dependencias públicas.
 
 ### Generar Prisma Client sin conexión
 Si el entorno bloquea la descarga de binarios de Prisma, defina `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1` antes de ejecutar `npx prisma generate` para omitir la verificación de suma.
+
+### Configuración del entorno
+Copie el archivo `.env.example` a `.env` y ajuste la variable `DATABASE_URL` con la cadena de conexión de PostgreSQL.
+Si utiliza `docker-compose`, no agregue comillas alrededor de la URL para evitar que se pasen al contenedor.
+La URL debe comenzar con `postgresql://` o `postgres://` según la [documentación oficial de Prisma](https://www.prisma.io/docs/orm/prisma-schema#datasource). También configure `EVOLUTION_API_URL` con la ruta base de Evolution API v2 y ajuste el resto de variables de acuerdo con su cuenta de GoHighLevel y Evolution API.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main"
+    "start:prod": "node dist/src/main.js"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.0",

--- a/src/auth.controller.ts
+++ b/src/auth.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Post, Res, Body, Query, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import { AuthService } from './auth.service';
+
+@Controller('oauth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('external-auth-credentials')
+  async externalAuth(
+    @Query('instance_id') instanceIdParam: string,
+    @Query('instanceId') instanceIdCamel: string,
+    @Query('api_token_instance') tokenParam: string,
+    @Query('instanceToken') tokenCamel: string,
+    @Body('instance_id') bodyInstanceIdParam: string,
+    @Body('instanceId') bodyInstanceIdCamel: string,
+    @Body('api_token_instance') bodyTokenParam: string,
+    @Body('instanceToken') bodyTokenCamel: string,
+    @Res() res: Response,
+  ) {
+    const instanceId =
+      bodyInstanceIdCamel ||
+      bodyInstanceIdParam ||
+      instanceIdCamel ||
+      instanceIdParam;
+
+    const instanceToken =
+      bodyTokenCamel ||
+      bodyTokenParam ||
+      tokenCamel ||
+      tokenParam;
+
+    if (!instanceId || !instanceToken) {
+      return res.status(HttpStatus.BAD_REQUEST).json({
+        success: false,
+        message: 'Missing instanceId or instanceToken',
+      });
+    }
+
+    try {
+      const status = await this.authService.validateInstance(instanceId, instanceToken);
+      return res.status(HttpStatus.OK).json({
+        success: true,
+        instanceId,
+        instanceToken,
+        status,
+      });
+    } catch (error: any) {
+      return res.status(HttpStatus.UNAUTHORIZED).json({
+        success: false,
+        message: error.message,
+      });
+    }
+  }
+}

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { EvolutionService } from './evolution/evolution.service';
+
+@Injectable()
+export class AuthService {
+  constructor(private readonly evolution: EvolutionService) {}
+
+  async validateInstance(instanceId: string, token: string): Promise<any> {
+    try {
+      const status = await this.evolution.getInstanceStatus(token);
+      // If API provides instance identifier, ensure it matches
+      const returnedId = status?.idInstance || status?.instanceId || status?.instance_id;
+      if (returnedId && returnedId.toString() !== instanceId.toString()) {
+        throw new UnauthorizedException('Instance ID mismatch');
+      }
+      return status;
+    } catch (error: any) {
+      throw new UnauthorizedException(error.message || 'Invalid Evolution API credentials');
+    }
+  }
+}

--- a/src/evolution/evolution.module.ts
+++ b/src/evolution/evolution.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { EvolutionService } from './evolution.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [HttpModule, PrismaModule],
+  providers: [EvolutionService],
+  exports: [EvolutionService],
+})
+export class EvolutionModule {}

--- a/src/oauth/oauth.module.ts
+++ b/src/oauth/oauth.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { GhlOauthController } from "./oauth.controller";
+import { AuthController } from "../auth.controller";
+import { AuthService } from "../auth.service";
 import { ConfigModule } from "@nestjs/config";
-import { PrismaService } from "../prisma/prisma.service";
-import { GhlOAuthCallbackDto } from "./dto/ghl-oauth-callback.dto";
+import { EvolutionModule } from "../evolution/evolution.module";
 
 @Module({
-  imports: [ConfigModule], // para poder usar ConfigService
-  controllers: [GhlOauthController],
-  providers: [PrismaService],
+  imports: [ConfigModule, EvolutionModule],
+  controllers: [GhlOauthController, AuthController],
+  providers: [AuthService],
 })
 export class OauthModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -25,7 +25,33 @@ export class PrismaService
     > {
   private readonly logger = new Logger(PrismaService.name);
 
+  constructor() {
+    const rawUrl = process.env.DATABASE_URL || '';
+    let dbUrl = rawUrl.trim();
+    if (dbUrl.startsWith('"') && dbUrl.endsWith('"')) {
+      dbUrl = dbUrl.slice(1, -1);
+      process.env.DATABASE_URL = dbUrl;
+    }
+
+    if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      // Throw early before PrismaClient tries to read the schema
+      throw new Error(
+        'Invalid DATABASE_URL. It must start with "postgresql://" or "postgres://"',
+      );
+    }
+
+    super();
+  }
+
   async onModuleInit() {
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl || (!dbUrl.startsWith('postgresql://') && !dbUrl.startsWith('postgres://'))) {
+      this.logger.error(
+        'Invalid DATABASE_URL. It must start with "postgresql://" or "postgres://"',
+      );
+      throw new Error('Invalid DATABASE_URL');
+    }
+
     const retries = parseInt(process.env.DB_CONNECT_RETRIES || '5', 10);
     const delayMs = parseInt(process.env.DB_CONNECT_DELAY_MS || '2000', 10);
 


### PR DESCRIPTION
## Summary
- support Environment variable for Evolution API base URL
- verify Evolution credentials through new AuthService
- allow `/oauth/external-auth-credentials` to read params from body or query
- expose EvolutionService via its own module
- fix production start script path

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b45c764c8322a93310f5a14afe22