### PR TITLE
Improve Evolution API error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Error Handling Examples
+
+`AuthService.validateInstance` now exposes clearer errors when communicating with
+the Evolution API.
+
+```ts
+try {
+  await authService.validateInstance('your-instance-id', 'invalid-token');
+} catch (error) {
+  // Possible messages:
+  // - "Evolution API responded with status 401: Unauthorized"
+  // - "Evolution API unreachable"
+  console.error(error.message);
+}
+```

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -8,14 +8,38 @@ export class AuthService {
   async validateInstance(instanceId: string, token: string): Promise<any> {
     try {
       const status = await this.evolution.getInstanceStatus(token);
+
       // If API provides instance identifier, ensure it matches
-      const returnedId = status?.idInstance || status?.instanceId || status?.instance_id;
+      const returnedId =
+        status?.idInstance || status?.instanceId || status?.instance_id;
       if (returnedId && returnedId.toString() !== instanceId.toString()) {
         throw new UnauthorizedException('Instance ID mismatch');
       }
+
       return status;
     } catch (error: any) {
-      throw new UnauthorizedException(error.message || 'Invalid Evolution API credentials');
+      // Handle Axios errors (network issues or non-2xx responses)
+      if (error?.isAxiosError) {
+        if (error.response) {
+          const statusCode = error.response.status;
+          const message =
+            error.response.data?.message || error.response.statusText || '';
+          throw new UnauthorizedException(
+            `Evolution API responded with status ${statusCode}${
+              message ? `: ${message}` : ''
+            }`,
+          );
+        }
+        // No response indicates the API couldn't be reached
+        throw new UnauthorizedException('Evolution API unreachable');
+      }
+
+      // Forward HttpException messages from EvolutionService
+      if (error?.message) {
+        throw new UnauthorizedException(error.message);
+      }
+
+      throw new UnauthorizedException('Invalid Evolution API credentials');
     }
   }
 }


### PR DESCRIPTION
## Summary
- expose clearer errors when validating an instance
- document example handling for Evolution API failures

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872fbe0f29c8322a1932ffafa1f73ff