### PR TITLE
Fix idInstance type mismatch

### DIFF
--- a/src/ghl/ghl.controller.ts
+++ b/src/ghl/ghl.controller.ts
@@ -119,14 +119,14 @@ export class GhlController {
 
 	@Delete(":instanceId")
 	async deleteInstance(@Param("instanceId") instanceId: string, @Req() req: AuthReq) {
-		const instance = await this.prisma.getInstance(BigInt(instanceId));
+        const instance = await this.prisma.getInstance(instanceId);
 		if (!instance || (instance.userId !== req.locationId)) {
 			throw new HttpException("Unauthorized", HttpStatus.FORBIDDEN);
 		}
 		this.logger.log(`Deleting instance: ${instanceId}`);
 
 		try {
-			await this.prisma.removeInstance(BigInt(instanceId));
+                    await this.prisma.removeInstance(instanceId);
 
 			return {
 				success: true,
@@ -152,12 +152,12 @@ export class GhlController {
 	) {
 		this.logger.log(`Updating instance: ${instanceId}`);
 		try {
-			let instance = await this.prisma.getInstance(BigInt(instanceId));
+                        let instance = await this.prisma.getInstance(instanceId);
 			if (!instance) {
 				throw new HttpException("Instance not found", HttpStatus.NOT_FOUND);
 			}
 			if (dto.name) {
-				instance = await this.prisma.updateInstanceName(BigInt(instanceId), dto.name);
+                                instance = await this.prisma.updateInstanceName(instanceId, dto.name);
 			}
 
 			return {

--- a/src/ghl/ghl.service.ts
+++ b/src/ghl/ghl.service.ts
@@ -266,7 +266,10 @@ export class GhlService extends BaseAdapter<
     return sorted[0];
   }
 
-  async handlePlatformWebhook(ghlWebhook: GhlWebhookDto, instanceId: bigint): Promise<void> {
+  async handlePlatformWebhook(
+    ghlWebhook: GhlWebhookDto,
+    instanceId: string | number,
+  ): Promise<void> {
     try {
       const message: GhlPlatformMessage = {
         direction: "outbound",
@@ -302,7 +305,7 @@ export class GhlService extends BaseAdapter<
   }
 
   async handleEvolutionWebhook(webhook: EvolutionWebhook): Promise<void> {
-    const idInstance = BigInt(webhook.instanceId as any);
+    const idInstance = webhook.instanceId?.toString();
 
     const instance = await this.prisma.instance.findFirst({
       where: { idInstance },
@@ -328,12 +331,12 @@ export class GhlService extends BaseAdapter<
   }
 
   async updateInstanceState(
-    instanceId: string | number | bigint,
+    instanceId: string | number,
     newState: InstanceState | string,
   ): Promise<void> {
     try {
       await this.prisma.instance.update({
-        where: { idInstance: BigInt(instanceId as any) },
+        where: { idInstance: instanceId.toString() },
         data: {
           stateInstance: newState as InstanceState,
         },
@@ -346,12 +349,12 @@ export class GhlService extends BaseAdapter<
 
   async createEvolutionApiInstanceForUser(
     userId: string,
-    instanceId: string | number | bigint,
+    instanceId: string | number,
     apiToken: string,
     wid?: string,
     name?: string,
   ): Promise<Instance> {
-    const idInst = BigInt(instanceId as any);
+    const idInst = instanceId.toString();
 
     const existing = await this.prisma.instance.findFirst({
       where: { idInstance: idInst },
@@ -367,7 +370,7 @@ export class GhlService extends BaseAdapter<
       const status = await this.evolutionService.getInstanceStatus(apiToken);
       const returnedId =
         status?.idInstance || status?.instanceId || status?.instance_id;
-      if (returnedId && BigInt(returnedId) !== idInst) {
+      if (returnedId && returnedId.toString() !== idInst) {
         throw new IntegrationError("Instance ID mismatch");
       }
 
@@ -409,14 +412,14 @@ export class GhlService extends BaseAdapter<
   }
 
   async handleStateWebhook(
-    instanceId: string | number | bigint,
+    instanceId: string | number,
     newState: string,
     wid?: string,
   ): Promise<void> {
     await this.updateInstanceState(instanceId, newState as InstanceState);
 
     if (wid) {
-      const idInst = BigInt(instanceId as any);
+      const idInst = instanceId.toString();
       const instance = await this.prisma.instance.findUnique({
         where: { idInstance: idInst },
       });

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -14,8 +14,8 @@ import {
   UserUpdateData,
 } from '../types';
 
-function parseBigInt(id: number | string | bigint): bigint {
-  return typeof id === 'bigint' ? id : BigInt(id);
+function parseId(id: number | string | bigint): string {
+  return typeof id === 'string' ? id : id.toString();
 }
 
 @Injectable()
@@ -133,7 +133,7 @@ export class PrismaService
   async createInstance(instanceData: any): Promise<Instance> {
     const ghlLocationId = instanceData.user?.connect?.id;
     const stateInstance = instanceData.stateInstance;
-    const idInstance = parseBigInt(instanceData.idInstance);
+    const idInstance = parseId(instanceData.idInstance);
 
     if (!ghlLocationId) {
       throw new Error(
@@ -182,7 +182,7 @@ export class PrismaService
 
   async getInstance(idInstance: number | string | bigint): Promise<(Instance & { user: User }) | null> {
     return (await this.instance.findUnique({
-      where: { idInstance: parseBigInt(idInstance) },
+      where: { idInstance: parseId(idInstance) },
       include: { user: true },
     })) as unknown as (Instance & { user: User }) | null;
   }
@@ -197,7 +197,7 @@ export class PrismaService
   async removeInstance(idInstance: number | string | bigint): Promise<Instance> {
     try {
       const instance = await this.instance.delete({
-        where: { idInstance: parseBigInt(idInstance) },
+        where: { idInstance: parseId(idInstance) },
       });
       this.logger.log(`Instance ${instance.idInstance} removed`);
       return instance as any;
@@ -210,7 +210,7 @@ export class PrismaService
   async updateInstanceSettings(idInstance: number | string | bigint, settings: Settings): Promise<Instance> {
     try {
       const instance = await this.instance.update({
-        where: { idInstance: parseBigInt(idInstance) },
+        where: { idInstance: parseId(idInstance) },
         data: { settings: settings || {} },
       });
       this.logger.log(`Settings updated for instance ${instance.idInstance}`);
@@ -224,7 +224,7 @@ export class PrismaService
   async updateInstanceState(idInstance: number | string | bigint, state: InstanceState): Promise<Instance> {
     try {
       const instance = await this.instance.update({
-        where: { idInstance: parseBigInt(idInstance) },
+        where: { idInstance: parseId(idInstance) },
         data: { stateInstance: state },
       });
       this.logger.log(`State updated for instance ${instance.idInstance} -> ${state}`);
@@ -238,7 +238,7 @@ export class PrismaService
   async updateInstanceName(idInstance: number | string | bigint, name: string): Promise<Instance & { user: User }> {
     try {
       const instance = await this.instance.update({
-        where: { idInstance: parseBigInt(idInstance) },
+        where: { idInstance: parseId(idInstance) },
         data: { name },
         include: { user: true },
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,8 +19,8 @@ export enum InstanceState {
 }
 
 export interface Instance {
-  id: bigint;
-  idInstance: bigint;
+  id: string;
+  idInstance: string;
   name?: string | null;
   phoneNumber?: string | null;
   apiTokenInstance: string;

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -103,7 +103,7 @@ export class WebhooksController {
       res.status(HttpStatus.OK).send();
 
       if (ghlWebhook.type === "SMS" && (ghlWebhook.message || (ghlWebhook.attachments?.length > 0))) {
-        await this.ghlService.handlePlatformWebhook(ghlWebhook, BigInt(instanceId));
+        await this.ghlService.handlePlatformWebhook(ghlWebhook, instanceId as string);
       }
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- align `Instance` interface fields with Prisma by using string IDs
- convert instance id handling across services/controllers to use strings
- update Prisma service helper to return string IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68741499801c8322b821329e5309599b