### PR TITLE
Use string instance IDs

### DIFF
--- a/src/evolutionapi/index.ts
+++ b/src/evolutionapi/index.ts
@@ -10,12 +10,12 @@ export interface StorageProvider<User, Instance, UserCreateData, UserUpdateData>
   getUserWithTokens(userId: string): Promise<User | null>;
   updateUserTokens(userId: string, accessToken: string, refreshToken: string, tokenExpiresAt: Date): Promise<User>;
   createInstance(data: any): Promise<Instance>;
-  getInstance(idInstance: string | number): Promise<Instance | null | (Instance & { user: User })>;
+  getInstance(idInstance: string): Promise<Instance | null | (Instance & { user: User })>;
   getInstancesByUserId(userId: string): Promise<Instance[]>;
-  removeInstance(idInstance: string | number): Promise<Instance>;
-  updateInstanceSettings(idInstance: string | number, settings: Settings): Promise<Instance>;
-  updateInstanceState(idInstance: string | number, state: any): Promise<Instance>;
-  updateInstanceName(idInstance: string | number, name: string): Promise<Instance & { user: User }>;
+  removeInstance(idInstance: string): Promise<Instance>;
+  updateInstanceSettings(idInstance: string, settings: Settings): Promise<Instance>;
+  updateInstanceState(idInstance: string, state: any): Promise<Instance>;
+  updateInstanceName(idInstance: string, name: string): Promise<Instance & { user: User }>;
 }
 
 import { Logger } from '@nestjs/common';

--- a/src/ghl/ghl.service.ts
+++ b/src/ghl/ghl.service.ts
@@ -15,7 +15,7 @@ import {
   IntegrationError,
 } from '../core/base-adapter';
 import { GhlTransformer } from './ghl.transformer';
-import { PrismaService } from '../prisma/prisma.service';
+import { PrismaService, parseId } from '../prisma/prisma.service';
 import { EvolutionService } from '../evolution/evolution.service';
 import { GhlWebhookDto } from './dto/ghl-webhook.dto';
 import {
@@ -293,7 +293,7 @@ export class GhlService extends BaseAdapter<
   
   async handlePlatformWebhook(
     ghlWebhook: GhlWebhookDto,
-    instanceId: string | number,
+    instanceId: string,
   ): Promise<void> {
     try {
       const message: GhlPlatformMessage = {
@@ -307,7 +307,7 @@ export class GhlService extends BaseAdapter<
       };
 
       const inst = await this.prisma.instance.findUnique({
-        where: { idInstance: instanceId.toString() },
+        where: { idInstance: parseId(instanceId) },
       });
 
       if (!inst) {
@@ -330,7 +330,9 @@ export class GhlService extends BaseAdapter<
   }
 
   async handleEvolutionWebhook(webhook: EvolutionWebhook): Promise<void> {
-    const idInstance = webhook.instanceId?.toString();
+    const idInstance = webhook.instanceId
+      ? parseId(webhook.instanceId)
+      : undefined;
 
     const instance = await this.prisma.instance.findFirst({
       where: { idInstance },
@@ -360,12 +362,12 @@ export class GhlService extends BaseAdapter<
 // Parte 7 - Gestión de estado e instancias (crear, actualizar, manejar state webhooks)
 
   async updateInstanceState(
-    instanceId: string | number,
+    instanceId: string,
     newState: InstanceState | string,
   ): Promise<void> {
     try {
       await this.prisma.instance.update({
-        where: { idInstance: instanceId.toString() },
+        where: { idInstance: parseId(instanceId) },
         data: {
           stateInstance: newState as InstanceState,
         },
@@ -400,12 +402,12 @@ async verifyEvolutionInstance(instanceId: string, apiToken: string): Promise<boo
   
   async createEvolutionApiInstanceForUser(
     userId: string,
-    instanceId: string | number,
+    instanceId: string,
     apiToken: string,
     wid?: string,
     name?: string,
   ): Promise<Instance> {
-    const idInst = instanceId.toString();
+    const idInst = parseId(instanceId);
 
     const existing = await this.prisma.instance.findFirst({
       where: { idInstance: idInst },
@@ -460,14 +462,14 @@ async verifyEvolutionInstance(instanceId: string, apiToken: string): Promise<boo
   }
 
   async handleStateWebhook(
-    instanceId: string | number,
+    instanceId: string,
     newState: string,
     wid?: string,
   ): Promise<void> {
     await this.updateInstanceState(instanceId, newState as InstanceState);
 
     if (wid) {
-      const idInst = instanceId.toString();
+      const idInst = parseId(instanceId);
       const instance = await this.prisma.instance.findUnique({
         where: { idInstance: idInst },
       });

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -136,48 +136,37 @@ export class GhlOauthController {
     }
   }
 
-  @Post('external-auth-credentials')
-  @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
-  async handleExternalAuthCredentials(
-    @Query('instance_id') queryInstanceId: string,
-    @Query('api_token_instance') queryApiToken: string,
-    @Query('locationId') queryLocationId: string,
-    @Body() body: GhlExternalAuthPayloadDto,
-  ): Promise<{ message: string }> {
-    const instanceId = queryInstanceId || body?.instance_id;
-    const apiToken = queryApiToken || body?.api_token_instance;
-    const locationId = queryLocationId || body?.locationId?.[0];
-
-
 @Post('external-auth-credentials')
 @HttpCode(HttpStatus.OK)
-async handleExternalAuthCredentials(@Body() data: GhlExternalAuthPayloadDto) {
-  if (!data.locationId || data.locationId.length === 0) {
+@UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
+async handleExternalAuthCredentials(
+  @Query('instance_id') queryInstanceId: string,
+  @Query('api_token_instance') queryApiToken: string,
+  @Query('locationId') queryLocationId: string,
+  @Body() body: GhlExternalAuthPayloadDto,
+): Promise<{ message: string }> {
+  const instanceId = queryInstanceId || body?.instance_id;
+  const apiToken = queryApiToken || body?.api_token_instance;
+  const locationId = queryLocationId || body?.locationId?.[0];
+
+  if (!locationId) {
     throw new HttpException('locationId is missing', HttpStatus.BAD_REQUEST);
   }
-  if (!data.instance_id || !data.api_token_instance) {
+  if (!instanceId || !apiToken) {
     throw new HttpException('Missing Evolution API credentials', HttpStatus.BAD_REQUEST);
   }
 
-  const ghlUser = await this.prisma.findUser(data.locationId[0]);
-  if (!ghlUser) {
+  const user = await this.prisma.findUser(locationId);
+  if (!user) {
     throw new HttpException(
-      {
-        success: false,
-        message: 'OAuth step might have failed or been skipped.',
-      },
+      'OAuth step might have failed or been skipped.',
       HttpStatus.BAD_REQUEST,
     );
   }
 
-  await this.ghlService.createEvolutionApiInstanceForUser(
-    data.locationId[0],
-    data.instance_id,
-    data.api_token_instance,
-  );
+  await this.ghlService.createEvolutionApiInstanceForUser(locationId, instanceId, apiToken);
 
-  return { success: true, message: 'Evolution API instance connected successfully.' };
+  return { message: 'Evolution API instance connected successfully.' };
 }
 
 

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -186,7 +186,7 @@ export class PrismaService
     }
   }
 
-  async getInstance(idInstance: string | number): Promise<(Instance & { user: User }) | null> {
+  async getInstance(idInstance: string): Promise<(Instance & { user: User }) | null> {
     return (await this.instance.findUnique({
       where: { idInstance: parseId(idInstance) },
       include: { user: true },
@@ -200,7 +200,7 @@ export class PrismaService
     })) as unknown as Instance[];
   }
 
-  async removeInstance(idInstance: string | number): Promise<Instance> {
+  async removeInstance(idInstance: string): Promise<Instance> {
     try {
       const instance = await this.instance.delete({
         where: { idInstance: parseId(idInstance) },
@@ -213,7 +213,7 @@ export class PrismaService
     }
   }
 
-  async updateInstanceSettings(idInstance: string | number, settings: Settings): Promise<Instance> {
+  async updateInstanceSettings(idInstance: string, settings: Settings): Promise<Instance> {
     try {
       const instance = await this.instance.update({
         where: { idInstance: parseId(idInstance) },
@@ -227,7 +227,7 @@ export class PrismaService
     }
   }
 
-  async updateInstanceState(idInstance: string | number, state: InstanceState): Promise<Instance> {
+  async updateInstanceState(idInstance: string, state: InstanceState): Promise<Instance> {
     try {
       const instance = await this.instance.update({
         where: { idInstance: parseId(idInstance) },
@@ -241,7 +241,7 @@ export class PrismaService
     }
   }
 
-  async updateInstanceName(idInstance: string | number, name: string): Promise<Instance & { user: User }> {
+  async updateInstanceName(idInstance: string, name: string): Promise<Instance & { user: User }> {
     try {
       const instance = await this.instance.update({
         where: { idInstance: parseId(idInstance) },

--- a/src/types/evolution-webhook.interface.ts
+++ b/src/types/evolution-webhook.interface.ts
@@ -2,7 +2,7 @@ export interface EvolutionWebhook {
   type: "message" | "incomingCall" | string;
   timestamp: number;
   from?: string;
-  instanceId?: string | number;
+  instanceId?: string;
   messageData?: {
     idMessage: string;
     typeMessage: string;


### PR DESCRIPTION
## Summary
- switch Evolution API IDs to strings across services
- fix `parseId` usage in `GhlService`
- clean up OAuth controller merge artifacts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877014697b48322a670aa0bd133cd1a