### PR TITLE
Fix BaseAdapter logger and GhlService method visibility

### DIFF
--- a/src/core/base-adapter.ts
+++ b/src/core/base-adapter.ts
@@ -1,14 +1,20 @@
 // src/core/base-adapter.ts
 
-import { MessageTransformer, StorageProvider, NotFoundError, IntegrationError } from '../evolutionapi';
 import { Logger } from '@nestjs/common';
+import { MessageTransformer, StorageProvider, NotFoundError, IntegrationError } from '../evolutionapi';
 
 export { MessageTransformer, StorageProvider, NotFoundError, IntegrationError };
 
 export abstract class BaseAdapter<T, U, V, W> {
+  // El logger se declara aquí pero se inicializa en el constructor.
+  protected readonly logger: Logger;
+
   constructor(
     protected readonly transformer: MessageTransformer<T, U>,
     protected readonly storage: StorageProvider<V, W, any, any>,
-    protected readonly logger: Logger,
-  ) {}
+  ) {
+    // Inicializa el logger usando el nombre de la clase que lo extiende (ej. GhlService).
+    // Esto resuelve la necesidad de pasar el logger en el super().
+    this.logger = new Logger(this.constructor.name);
+  }
 }

--- a/src/ghl/ghl.service.ts
+++ b/src/ghl/ghl.service.ts
@@ -12,8 +12,7 @@ import { User, Instance, GhlPlatformMessage, EvolutionWebhook, GhlContact, GhlCo
 
 @Injectable()
 export class GhlService extends BaseAdapter<GhlPlatformMessage, EvolutionWebhook, User, Instance> {
-  // --- CORREGIDO: El logger ahora es 'protected' para coincidir con la clase base ---
-  protected readonly logger = new Logger(GhlService.name);
+  // El logger ya no se declara aquí, es heredado y manejado por BaseAdapter.
 
   private readonly ghlApiBaseUrl = 'https://services.leadconnectorhq.com';
   private readonly ghlApiVersion = '2021-07-28';
@@ -61,6 +60,19 @@ export class GhlService extends BaseAdapter<GhlPlatformMessage, EvolutionWebhook
     });
     const response = await axios.post(`${this.ghlApiBaseUrl}/oauth/token`, body, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' }});
     return response.data;
+  }
+
+  // --- CORREGIDO: Este método ahora es 'public' para ser accesible desde otros archivos. ---
+  public async getGhlContactByPhone(locationId: string, phone: string): Promise<GhlContact | null> {
+    const httpClient = await this.getHttpClient(locationId);
+    try {
+      const response = await httpClient.get(`/contacts/lookup?phone=${encodeURIComponent(phone)}`);
+      return (response.data?.contacts?.[0]) || null;
+    } catch (error) {
+      if ((error as AxiosError).response?.status === 404) return null;
+      this.logger.error(`Error fetching contact by phone in GHL: ${error.message}`);
+      throw error;
+    }
   }
 
   private async findOrCreateGhlContact(locationId: string, phone: string, name: string, instanceId: string): Promise<GhlContact> {


### PR DESCRIPTION
## Summary
- initialize logger inside BaseAdapter
- remove manual logger from `GhlService` and expose `getGhlContactByPhone`

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877a5e33d888322bf2638b49eceeeb0