### PR TITLE
Fix bridge service command indentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
       - GHL_CONVERSATION_PROVIDER_ID=${GHL_CONVERSATION_PROVIDER_ID}
       - APP_URL=${APP_URL}
       - GHL_SHARED_SECRET=${GHL_SHARED_SECRET}
-  command: sh -c "npx prisma migrate deploy && npm run build && npm run start:prod"
-  restart: unless-stopped
+    command: sh -c "npx prisma migrate deploy && npm run build && npm run start:prod"
+    restart: unless-stopped
 
 secrets:
   npm_token:


### PR DESCRIPTION
## Summary
- indent `command` and `restart` under the `bridge` service
- validate compose file

## Testing
- `docker compose config`

------
https://chatgpt.com/codex/tasks/task_e_6877bd83e170832283cedb3135ff367f