### PR TITLE
Align instance verification with Evolution API

### DIFF
--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -6,19 +6,15 @@ import {
   Body,
   HttpCode,
   Res,
-  Req,
   HttpException,
   HttpStatus,
   Logger,
-  UsePipes,
-  ValidationPipe,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import axios from 'axios';
 import { PrismaService } from '../prisma/prisma.service';
 import { GhlOAuthCallbackDto } from './dto/ghl-oauth-callback.dto';
-import { GhlExternalAuthPayloadDto } from './dto/ghl-external-auth-payload.dto';
 import { EvolutionApiService } from '../evolution-api/evolution-api.service';
 
 @Controller('oauth')
@@ -134,35 +130,45 @@ export class GhlOauthController {
     }
   }
 
+
 @Post('external-auth-credentials')
 @HttpCode(HttpStatus.OK)
-@UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
 async handleExternalAuthCredentials(
-  @Query('instance_id') queryInstanceId: string,
-  @Query('api_token_instance') queryApiToken: string,
-  @Query('locationId') queryLocationId: string,
-  @Body() body: GhlExternalAuthPayloadDto,
+  @Query('instance_id') instanceId: string,
+  @Query('api_token_instance') apiToken: string,
+  @Body() body: { locationId?: string | string[] },
 ): Promise<{ message: string }> {
-  const instanceId = queryInstanceId || body?.instance_id;
-  const apiToken = queryApiToken || body?.api_token_instance;
-  const locationId = queryLocationId || body?.locationId?.[0];
+  this.logger.log(`Handling external auth credentials for instance: ${instanceId}`);
+
+  let locationId: string | undefined;
+  if (Array.isArray(body.locationId) && body.locationId.length > 0) {
+    locationId = body.locationId[0];
+  } else if (typeof body.locationId === 'string') {
+    locationId = body.locationId;
+  }
 
   if (!locationId) {
-    throw new HttpException('locationId is missing', HttpStatus.BAD_REQUEST);
+    this.logger.error('Verification failed: locationId is missing from the request body.', body);
+    throw new HttpException('locationId is missing from the request body.', HttpStatus.BAD_REQUEST);
   }
+
   if (!instanceId || !apiToken) {
-    throw new HttpException('Missing Evolution API credentials', HttpStatus.BAD_REQUEST);
+    this.logger.error('Verification failed: Missing instance_id or api_token_instance in query parameters.');
+    throw new HttpException('Missing Evolution API credentials in query parameters.', HttpStatus.BAD_REQUEST);
   }
 
   const user = await this.prisma.findUser(locationId);
   if (!user) {
+    this.logger.error(`User not found for locationId: ${locationId}. The OAuth process must be completed first.`);
     throw new HttpException(
-      'OAuth step might have failed or been skipped.',
-      HttpStatus.BAD_REQUEST,
+      'User authentication not found. Please complete the OAuth step first.',
+      HttpStatus.FORBIDDEN,
     );
   }
 
   await this.evolutionApiService.createEvolutionApiInstanceForUser(locationId, instanceId, apiToken);
+
+  this.logger.log(`Successfully verified and created instance ${instanceId} for location ${locationId}.`);
 
   return { message: 'Evolution API instance connected successfully.' };
 }
@@ -170,55 +176,7 @@ async handleExternalAuthCredentials(
 
 
 
-
    
-  @Post('external-auth-body')
-  @HttpCode(HttpStatus.OK)
-  @UsePipes(new ValidationPipe({ whitelist: true, transform: true }))
-  async handleExternalAuthBody(
-    @Body() payload: GhlExternalAuthPayloadDto,
-  ): Promise<{ message: string }> {
-    const instanceId = payload.instance_id;
-    const apiToken = payload.api_token_instance;
-    const locationId = Array.isArray(payload.locationId)
-      ? payload.locationId[0]
-      : payload.locationId;
-
-    this.logger.log(
-      `Received external auth via body - instanceId: ${instanceId}, locationId: ${locationId}`,
-    );
-
-    if (!locationId || !instanceId || !apiToken) {
-      throw new HttpException('Missing required fields in body', HttpStatus.BAD_REQUEST);
-    }
-
-    const user = await this.prisma.user.findUnique({ where: { id: locationId } });
-    if (!user) {
-      throw new HttpException(
-        'OAuth must be completed before submitting instance credentials.',
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-
-    try {
-      await this.evolutionApiService.createEvolutionApiInstanceForUser(
-        locationId,
-        instanceId,
-        apiToken,
-      );
-
-      this.logger.log(
-        `Validated and stored instance ${instanceId} from body for location ${locationId}`,
-      );
-
-      return {
-        message: 'Valid credentials (from body)',
-      };
-    } catch (err) {
-      this.logger.error(`Credential validation (body) failed: ${err.message}`);
-      throw new HttpException('Invalid credentials (from body)', HttpStatus.UNAUTHORIZED);
-    }
-  }
 
   private generateSuccessHtml(): string {
     return `


### PR DESCRIPTION
## Summary
- simplify external auth endpoint to read instance credentials from query params and location id from the body
- drop old body-based endpoint and related validation pipeline

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d09482308322a091cb6fc1785be1