### PR TITLE
Refactor auth endpoints and align instance creation

### DIFF
--- a/src/evolution-api/evolution-api.controller.ts
+++ b/src/evolution-api/evolution-api.controller.ts
@@ -44,34 +44,37 @@ export class EvolutionApiController {
 
   @Post()
   async createInstance(@Req() req: AuthReq, @Body() dto: CreateInstanceDto) {
+    // El locationId se obtiene del contexto seguro verificado por GhlContextGuard.
     const { locationId } = req;
-    this.logger.log(`Creating instance for location: ${locationId}`);
+    this.logger.log(`Executing createInstance for location from context: ${locationId}`);
 
-    // La validación del DTO se puede hacer con Pipes de NestJS en el futuro
-    if (!dto.instanceId || !dto.apiToken) {
-        throw new HttpException('Instance ID and API Token are required', HttpStatus.BAD_REQUEST);
+    // Medida de seguridad: Asegura que el locationId del payload coincida con el del usuario autenticado.
+    if (locationId !== dto.locationId) {
+        throw new HttpException('Context and payload locationId mismatch. Unauthorized.', HttpStatus.FORBIDDEN);
     }
-    
-    // El GhlContextGuard ya asegura que el locationId es el correcto
-    dto.locationId = locationId;
+
+    // Validación de campos requeridos.
+    if (!dto.instanceId || !dto.apiToken) {
+        throw new HttpException('Instance ID and API Token are required fields.', HttpStatus.BAD_REQUEST);
+    }
 
     try {
+      // La lógica de validación y creación de la instancia ya está en el servicio.
       const instance = await this.evolutionApiService.createEvolutionApiInstanceForUser(
         dto.locationId,
         dto.instanceId,
         dto.apiToken,
         dto.name,
       );
-      return {
-        success: true,
-        instance,
-      };
+
+      return { success: true, instance };
     } catch (error) {
-      this.logger.error(`Error creating instance: ${error.message}`, error.stack);
+      this.logger.error(`Failed to create instance for location ${locationId}: ${error.message}`, error.stack);
       if (error instanceof HttpException) {
-        throw error;
+        throw error; // Re-lanza la excepción si ya es de tipo HTTP.
       }
-      throw new HttpException('Failed to create instance', HttpStatus.INTERNAL_SERVER_ERROR);
+      // Envuelve errores inesperados para una respuesta consistente.
+      throw new HttpException('Failed to create instance due to an internal server error.', HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -1,10 +1,7 @@
 import {
   Controller,
-  Post,
   Get,
   Query,
-  Body,
-  HttpCode,
   Res,
   HttpException,
   HttpStatus,
@@ -131,47 +128,6 @@ export class GhlOauthController {
   }
 
 
-@Post('external-auth-credentials')
-@HttpCode(HttpStatus.OK)
-async handleExternalAuthCredentials(
-  @Query('instance_id') instanceId: string,
-  @Query('api_token_instance') apiToken: string,
-  @Body() body: { locationId?: string | string[] },
-): Promise<{ message: string }> {
-  this.logger.log(`Handling external auth credentials for instance: ${instanceId}`);
-
-  let locationId: string | undefined;
-  if (Array.isArray(body.locationId) && body.locationId.length > 0) {
-    locationId = body.locationId[0];
-  } else if (typeof body.locationId === 'string') {
-    locationId = body.locationId;
-  }
-
-  if (!locationId) {
-    this.logger.error('Verification failed: locationId is missing from the request body.', body);
-    throw new HttpException('locationId is missing from the request body.', HttpStatus.BAD_REQUEST);
-  }
-
-  if (!instanceId || !apiToken) {
-    this.logger.error('Verification failed: Missing instance_id or api_token_instance in query parameters.');
-    throw new HttpException('Missing Evolution API credentials in query parameters.', HttpStatus.BAD_REQUEST);
-  }
-
-  const user = await this.prisma.findUser(locationId);
-  if (!user) {
-    this.logger.error(`User not found for locationId: ${locationId}. The OAuth process must be completed first.`);
-    throw new HttpException(
-      'User authentication not found. Please complete the OAuth step first.',
-      HttpStatus.FORBIDDEN,
-    );
-  }
-
-  await this.evolutionApiService.createEvolutionApiInstanceForUser(locationId, instanceId, apiToken);
-
-  this.logger.log(`Successfully verified and created instance ${instanceId} for location ${locationId}.`);
-
-  return { message: 'Evolution API instance connected successfully.' };
-}
 
 
 


### PR DESCRIPTION
## Summary
- drop obsolete External Authentication endpoints
- expect JSON POST for Evolution API instance creation
- enforce locationId consistency and improve error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877ed095ab48322bb59d4e1036b9a8c