### PR TITLE
Use Evolution instance name

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -3,7 +3,7 @@
 ## Introducción
 WLink Bridge es un servicio que conecta Evolution API con GoHighLevel. La integración requiere diversas variables de entorno, incluida `EVOLUTION_CONSOLE_URL` para apuntar a la consola de Evolution. Consulta `.env.example` para ver la lista completa de variables.
 
-Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Las funciones auxiliares convierten los identificadores numéricos en cadenas antes de las consultas a la base de datos.
+Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Cuando agregues una nueva instancia de Evolution debes indicar su **nombre de instancia** tal como aparece en la consola de Evolution. El servicio obtendrá automáticamente su ID antes de guardarla.
 
 ## Configuración
 1. Copia el archivo `.env.example` a `.env` y ajusta los valores.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 This service acts as a bridge between Evolution API and GoHighLevel. The integration requires several environment variables, including `EVOLUTION_CONSOLE_URL` to point to the Evolution API console. See `.env.example` for the complete list.
 
-All instance IDs are stored as strings to match the Prisma schema. Helper
-functions convert any numeric IDs to strings before database queries are
-performed.
+All instance IDs are stored as strings to match the Prisma schema. When
+registering a new Evolution instance you now provide its **instance name** as
+shown in the Evolution console. The service will look up the ID automatically
+before persisting it.
 
 ## Development
 

--- a/src/custom-page/custom-page.controller.ts
+++ b/src/custom-page/custom-page.controller.ts
@@ -153,16 +153,16 @@ export class CustomPageController {
               <div class="section"><h2>➕ Add New Instance</h2>
                 <form id="instanceForm">
                   <div class="form-group">
-                    <label for="instanceId">Instance ID</label>
-                    <input type="text" id="instanceId" name="instanceId" placeholder="e.g., my-instance-name" required>
+                    <label for="instanceName">Instance Name (from Evolution)</label>
+                    <input type="text" id="instanceName" name="instanceName" placeholder="e.g., my-instance-name" required>
                   </div>
                   <div class="form-group">
                     <label for="apiToken">API Token</label>
                     <input type="text" id="apiToken" name="apiToken" placeholder="Your Evolution API token" required>
                   </div>
                   <div class="form-group">
-                    <label for="instanceName">Instance Nickname (optional)</label>
-                    <input type="text" id="instanceName" name="instanceName" placeholder="e.g., Sales Team WhatsApp">
+                    <label for="instanceAlias">Instance Nickname (optional)</label>
+                    <input type="text" id="instanceAlias" name="instanceAlias" placeholder="e.g., Sales Team WhatsApp">
                   </div>
                   <button type="submit" id="submitBtn" class="btn">Add Instance</button>
                 </form>
@@ -338,9 +338,9 @@ export class CustomPageController {
               
               const payload = {
                 locationId: this.locationId,
-                instanceId: form.instanceId.value,
+                instanceName: form.instanceName.value,
                 apiToken: form.apiToken.value,
-                name: form.instanceName.value
+                name: form.instanceAlias.value
               };
 
               submitBtn.disabled = true;

--- a/src/evolution-api/evolution-api.controller.ts
+++ b/src/evolution-api/evolution-api.controller.ts
@@ -54,15 +54,15 @@ export class EvolutionApiController {
     }
 
     // Validación de campos requeridos.
-    if (!dto.instanceId || !dto.apiToken) {
-        throw new HttpException('Instance ID and API Token are required fields.', HttpStatus.BAD_REQUEST);
+    if (!dto.instanceName || !dto.apiToken) {
+        throw new HttpException('Instance Name and API Token are required fields.', HttpStatus.BAD_REQUEST);
     }
 
     try {
       // La lógica de validación y creación de la instancia ya está en el servicio.
       const instance = await this.evolutionApiService.createEvolutionApiInstanceForUser(
         dto.locationId,
-        dto.instanceId,
+        dto.instanceName,
         dto.apiToken,
         dto.name,
       );

--- a/src/evolution-api/evolution-api.service.ts
+++ b/src/evolution-api/evolution-api.service.ts
@@ -136,36 +136,42 @@ export class EvolutionApiService extends BaseAdapter<
     }
   }
 
-  public async createEvolutionApiInstanceForUser(userId: string, instanceId: string, apiToken: string, name?: string): Promise<Instance> {
-    const existing = await this.prisma.instance.findUnique({ where: { idInstance: parseId(instanceId) } });
-    if (existing) throw new HttpException('An instance with this ID already exists.', HttpStatus.CONFLICT);
-
-    // ✅ CORRECCIÓN: buscar instanceName antes de validar
-    let instanceName = instanceId;
+  public async createEvolutionApiInstanceForUser(
+    userId: string,
+    instanceName: string,
+    apiToken: string,
+    name?: string,
+  ): Promise<Instance> {
+    // Find instance by name from Evolution API
+    let foundId: string | null = null;
     try {
-      const { data } = await this.evolutionService.fetchInstances(apiToken);
-      const match = data.find((i: any) => i.id === instanceId);
-      if (!match) throw new Error('Instance ID not found in fetched list');
-      instanceName = match.name;
+      const instances = await this.evolutionService.fetchInstances(apiToken);
+      const match = instances.find((i: any) => i.name === instanceName);
+      if (!match) throw new Error('Instance name not found in fetched list');
+      foundId = match.id;
     } catch (err) {
-      this.logger.error(`Failed to fetch instance name for ${instanceId}`, err);
+      this.logger.error(`Failed to fetch instance id for ${instanceName}`, err);
       throw new HttpException('Invalid Evolution API credentials.', HttpStatus.BAD_REQUEST);
     }
+
+    // ensure not duplicated
+    const existing = await this.prisma.instance.findUnique({ where: { idInstance: parseId(foundId) } });
+    if (existing) throw new HttpException('An instance with this ID already exists.', HttpStatus.CONFLICT);
 
     try {
       await this.evolutionService.getInstanceStatus(apiToken, instanceName);
     } catch (err) {
-      this.logger.error(`Failed to verify Evolution API credentials for instance ${instanceId}.`, err);
+      this.logger.error(`Failed to verify Evolution API credentials for instance ${instanceName}.`, err);
       throw new HttpException('Invalid Evolution API credentials.', HttpStatus.BAD_REQUEST);
     }
 
     const newInstance = await this.prisma.createInstance({
-      idInstance: parseId(instanceId),
+      idInstance: parseId(foundId),
       apiTokenInstance: apiToken,
       user: {
         connect: { id: userId },
       },
-      name: name || `Evolution ${instanceId.substring(0, 8)}`,
+      name: name || `Evolution ${instanceName}`,
       stateInstance: 'authorized',
       settings: {},
     });
@@ -174,7 +180,7 @@ export class EvolutionApiService extends BaseAdapter<
     try {
       await this.evolutionService.configureWebhooks(apiToken, webhookUrl);
     } catch (err) {
-      this.logger.error(`Failed to configure webhooks for ${instanceId}.`, err);
+      this.logger.error(`Failed to configure webhooks for ${instanceName}.`, err);
     }
 
     return newInstance;

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -28,10 +28,10 @@ export class GhlOauthController {
   @Get('callback')
   async callback(
     @Query()
-    query: GhlOAuthCallbackDto & { idInstance?: string; apiTokenInstance?: string },
+    query: GhlOAuthCallbackDto & { instanceName?: string; apiTokenInstance?: string },
     @Res() res: Response,
   ) {
-    const { code, idInstance, apiTokenInstance } = query;
+    const { code, instanceName, apiTokenInstance } = query;
     this.logger.log(`GHL OAuth callback received. Code: ${code ? 'present' : 'MISSING'}`);
 
     if (!code) {
@@ -100,14 +100,14 @@ export class GhlOauthController {
 
       this.logger.log(`Stored/updated GHL tokens for Location: ${respLocationId}`);
 
-      if (idInstance && apiTokenInstance) {
+      if (instanceName && apiTokenInstance) {
         try {
           await this.evolutionApiService.createEvolutionApiInstanceForUser(
             respLocationId,
-            idInstance,
+            instanceName,
             apiTokenInstance,
           );
-          this.logger.log(`Evolution API instance ${idInstance} stored for location ${respLocationId}`);
+          this.logger.log(`Evolution API instance ${instanceName} stored for location ${respLocationId}`);
         } catch (err) {
           this.logger.error(`Failed to store Evolution API instance: ${err.message}`);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export type Instance = PrismaInstance;
 // --- DTOs (Data Transfer Objects) para las peticiones HTTP ---
 export interface CreateInstanceDto {
   locationId: string;
-  instanceId: string;
+  instanceName: string;
   apiToken: string;
   name?: string;
 }


### PR DESCRIPTION
## Summary
- update `CreateInstanceDto` to expect `instanceName`
- validate the new field in `EvolutionApiController`
- lookup instances by name in `EvolutionApiService`
- pass instance name in OAuth controller
- update custom page form and payload for `instanceName`
- clarify instance name requirement in docs

## Testing
- `npm test`
- `npm run build` *(fails: Prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b0ab798cc83229c213203f3b4b169