### PR TITLE
Use instance ID for Evolution validation

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -3,7 +3,7 @@
 ## Introducción
 WLink Bridge es un servicio que conecta Evolution API con GoHighLevel. La integración requiere diversas variables de entorno, incluida `EVOLUTION_CONSOLE_URL` para apuntar a la consola de Evolution. Consulta `.env.example` para ver la lista completa de variables.
 
-Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Las funciones auxiliares convierten los identificadores numéricos en cadenas antes de las consultas a la base de datos.
+Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Las funciones auxiliares convierten los identificadores numéricos en cadenas antes de las consultas a la base de datos. Al conectar una nueva instancia de Evolution es necesario proporcionar el `instanceId` junto con el token de API. El servicio valida estas credenciales antes de guardarlas.
 
 ## Configuración
 1. Copia el archivo `.env.example` a `.env` y ajusta los valores.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This service acts as a bridge between Evolution API and GoHighLevel. The integra
 
 All instance IDs are stored as strings to match the Prisma schema. Helper
 functions convert any numeric IDs to strings before database queries are
-performed.
+performed. When connecting a new Evolution instance you must provide the
+`instanceId` along with the API token. The service validates these
+credentials against Evolution before persisting the instance.
 
 ## Development
 

--- a/src/custom-page/custom-page.controller.ts
+++ b/src/custom-page/custom-page.controller.ts
@@ -154,7 +154,7 @@ export class CustomPageController {
                 <form id="instanceForm">
                   <div class="form-group">
                     <label for="instanceId">Instance ID</label>
-                    <input type="text" id="instanceId" name="instanceId" placeholder="e.g., my-instance-name" required>
+                    <input type="text" id="instanceId" name="instanceId" placeholder="e.g., 41ef815d-8c..." required>
                   </div>
                   <div class="form-group">
                     <label for="apiToken">API Token</label>

--- a/src/evolution-api/evolution-api.service.ts
+++ b/src/evolution-api/evolution-api.service.ts
@@ -136,24 +136,28 @@ export class EvolutionApiService extends BaseAdapter<
     }
   }
 
-  public async createEvolutionApiInstanceForUser(userId: string, instanceId: string, apiToken: string, name?: string): Promise<Instance> {
+  public async createEvolutionApiInstanceForUser(
+    userId: string,
+    instanceId: string,
+    apiToken: string,
+    name?: string,
+  ): Promise<Instance> {
     const existing = await this.prisma.instance.findUnique({ where: { idInstance: parseId(instanceId) } });
     if (existing) throw new HttpException('An instance with this ID already exists.', HttpStatus.CONFLICT);
 
-    // ✅ CORRECCIÓN: buscar instanceName antes de validar
+    // Look up instance name for display purposes
     let instanceName = instanceId;
     try {
-      const { data } = await this.evolutionService.fetchInstances(apiToken);
-      const match = data.find((i: any) => i.id === instanceId);
-      if (!match) throw new Error('Instance ID not found in fetched list');
-      instanceName = match.name;
+      const instances = await this.evolutionService.fetchInstances(apiToken);
+      const match = instances.find((i: any) => i.id === instanceId || i.id?.toString?.() === instanceId);
+      if (match) instanceName = match.name;
     } catch (err) {
       this.logger.error(`Failed to fetch instance name for ${instanceId}`, err);
       throw new HttpException('Invalid Evolution API credentials.', HttpStatus.BAD_REQUEST);
     }
 
     try {
-      await this.evolutionService.getInstanceStatus(apiToken, instanceName);
+      await this.evolutionService.getInstanceStatus(apiToken, instanceId);
     } catch (err) {
       this.logger.error(`Failed to verify Evolution API credentials for instance ${instanceId}.`, err);
       throw new HttpException('Invalid Evolution API credentials.', HttpStatus.BAD_REQUEST);
@@ -165,7 +169,7 @@ export class EvolutionApiService extends BaseAdapter<
       user: {
         connect: { id: userId },
       },
-      name: name || `Evolution ${instanceId.substring(0, 8)}`,
+      name: name || `Evolution ${instanceName}`,
       stateInstance: 'authorized',
       settings: {},
     });
@@ -174,7 +178,7 @@ export class EvolutionApiService extends BaseAdapter<
     try {
       await this.evolutionService.configureWebhooks(apiToken, webhookUrl);
     } catch (err) {
-      this.logger.error(`Failed to configure webhooks for ${instanceId}.`, err);
+      this.logger.error(`Failed to configure webhooks for ${instanceName}.`, err);
     }
 
     return newInstance;

--- a/src/evolution/evolution.service.ts
+++ b/src/evolution/evolution.service.ts
@@ -33,10 +33,10 @@ export class EvolutionService {
   }
 
   /**
-   * Verifica el estado de la instancia usando su nombre (no su ID interno).
+   * Checks the connection status of an Evolution instance by its ID.
    */
-  async getInstanceStatus(instanceToken: string, instanceName: string) {
-    const url = `${this.baseUrl}/instance/connectionState/${instanceName}`;
+  async getInstanceStatus(instanceToken: string, instanceId: string) {
+    const url = `${this.baseUrl}/instance/connectionState/${instanceId}`;
 
     try {
       const response$ = this.http.get(url, {
@@ -82,7 +82,7 @@ export class EvolutionService {
   /**
    * ✅ Nuevo método: Obtiene todas las instancias asociadas al token del usuario.
    */
-  async fetchInstances(instanceToken: string): Promise<{ name: string }[]> {
+  async fetchInstances(instanceToken: string): Promise<{ id: string; name: string }[]> {
     const url = `${this.baseUrl}/instances`;
 
     try {
@@ -90,7 +90,12 @@ export class EvolutionService {
         headers: { apikey: instanceToken },
       });
       const response = await lastValueFrom(response$);
-      return response.data.instances ?? [];
+      return (
+        response.data.instances?.map((i: any) => ({
+          id: i.id?.toString?.() || String(i.id),
+          name: i.name,
+        })) ?? []
+      );
     } catch (error) {
       throw new HttpException(
         'Error fetching instance list',


### PR DESCRIPTION
## Summary
- revert integration changes that used instance names
- validate Evolution API credentials using instance IDs
- restore original DTO and form fields
- clarify docs on supplying instanceId

## Testing
- `npm test`
- `npm run build` *(fails to compile Prisma client)*

------
https://chatgpt.com/codex/tasks/task_e_687b0ab798cc83229c213203f3b4b169