### PR TITLE
Handle missing Evolution env vars

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,7 +1,7 @@
 # WLink Bridge
 
 ## Introducción
-WLink Bridge es un servicio que conecta Evolution API con GoHighLevel. La integración requiere diversas variables de entorno, incluida `EVOLUTION_CONSOLE_URL` para apuntar a la consola de Evolution y `EVOLUTION_WEBHOOK_SECRET` para proteger los webhooks entrantes. Consulta `.env.example` para ver la lista completa de variables.
+WLink Bridge es un servicio que conecta Evolution API con GoHighLevel. La integración requiere diversas variables de entorno, incluida `EVOLUTION_CONSOLE_URL` para apuntar a la consola de Evolution. Las variables `EVOLUTION_API_URL` y `EVOLUTION_WEBHOOK_SECRET` deben estar definidas antes de iniciar la aplicación o ésta generará un error. Consulta `.env.example` para ver la lista completa de variables.
 
 Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Las funciones auxiliares convierten los identificadores numéricos en cadenas antes de las consultas a la base de datos. Al conectar una nueva instancia de Evolution es necesario proporcionar el `instanceId` junto con el token de API. El servicio valida estas credenciales antes de guardarlas.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WLink Bridge
 
-This service acts as a bridge between Evolution API and GoHighLevel. The integration requires several environment variables, including `EVOLUTION_CONSOLE_URL` to point to the Evolution API console and `EVOLUTION_WEBHOOK_SECRET` to secure incoming webhooks. See `.env.example` for the complete list.
+This service acts as a bridge between Evolution API and GoHighLevel. The integration requires several environment variables, including `EVOLUTION_CONSOLE_URL` to point to the Evolution API console. `EVOLUTION_API_URL` and `EVOLUTION_WEBHOOK_SECRET` must be defined before the application starts or it will throw an error. See `.env.example` for the complete list.
 
 
 All instance IDs are stored as strings to match the Prisma schema. Helper

--- a/src/evolution/evolution.service.ts
+++ b/src/evolution/evolution.service.ts
@@ -12,7 +12,11 @@ export class EvolutionService {
     private readonly http: HttpService,
     private readonly configService: ConfigService,
   ) {
-    this.baseUrl = this.configService.get<string>('EVOLUTION_API_URL')!;
+    const apiUrl = this.configService.get<string>('EVOLUTION_API_URL');
+    if (!apiUrl) {
+      throw new Error('EVOLUTION_API_URL is not configured');
+    }
+    this.baseUrl = apiUrl;
   }
 
   async sendMessage(instanceToken: string, to: string, message: string) {
@@ -60,6 +64,9 @@ export class EvolutionService {
     // El endpoint para configurar webhooks por instancia usa el NOMBRE de la instancia
     const url = `${this.baseUrl}/webhook/instance/${instanceName}`;
     const secret = this.configService.get<string>('EVOLUTION_WEBHOOK_SECRET');
+    if (!secret) {
+      throw new Error('EVOLUTION_WEBHOOK_SECRET is not configured');
+    }
 
     const payload = {
       url: webhookUrl,


### PR DESCRIPTION
## Summary
- load EVOLUTION_API_URL in constructor and fail fast if missing
- verify EVOLUTION_WEBHOOK_SECRET in configureWebhooks
- document required environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b4759a5448322bd2bb0cd4e572dd7