### PR TITLE
Add additional webhook token locations

### DIFF
--- a/src/webhooks/guards/evolution-api-webhook.guard.spec.ts
+++ b/src/webhooks/guards/evolution-api-webhook.guard.spec.ts
@@ -1,0 +1,33 @@
+import { ExecutionContext } from '@nestjs/common';
+import { EvolutionApiWebhookGuard } from './evolution-api-webhook.guard';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+
+describe('EvolutionApiWebhookGuard', () => {
+  let guard: EvolutionApiWebhookGuard;
+  let configService: ConfigService;
+
+  beforeEach(() => {
+    configService = { get: jest.fn().mockReturnValue('secret') } as any;
+    guard = new EvolutionApiWebhookGuard(configService);
+  });
+
+  const createContext = (request: Partial<Request>): ExecutionContext => ({
+    switchToHttp: () => ({ getRequest: () => request as Request }),
+  } as any);
+
+  it('allows token in headers', async () => {
+    const ctx = createContext({ headers: { 'x-evolution-token': 'secret' } as any });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows token in query', async () => {
+    const ctx = createContext({ headers: {}, query: { token: 'secret' } as any, body: {} });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+
+  it('allows token in body', async () => {
+    const ctx = createContext({ headers: {}, query: {}, body: { webhook_token: 'secret' } });
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  });
+});

--- a/src/webhooks/guards/evolution-api-webhook.guard.ts
+++ b/src/webhooks/guards/evolution-api-webhook.guard.ts
@@ -11,7 +11,13 @@ export class EvolutionApiWebhookGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
-    const token = (request.headers['x-evolution-token'] || request.headers['x-webhook-token']) as string;
+    let token = (request.headers['x-evolution-token'] || request.headers['x-webhook-token']) as string | undefined;
+    if (!token) {
+      token = request.query.token as string | undefined;
+    }
+    if (!token && request.body) {
+      token = (request.body as any).webhook_token as string | undefined;
+    }
     const secret = this.configService.get<string>('EVOLUTION_WEBHOOK_SECRET');
 
     // Si el secreto no está configurado en el servidor, rechaza la petición por seguridad.


### PR DESCRIPTION
## Summary
- allow EvolutionApiWebhookGuard to read token from query or body
- add unit tests for new token behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b475ae0748322a240a52a58d4dd54