### PR TITLE
Improve webhook logging

### DIFF
--- a/src/evolution/evolution.service.ts
+++ b/src/evolution/evolution.service.ts
@@ -1,5 +1,5 @@
 // src/evolution/evolution.service.ts
-import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
@@ -7,6 +7,7 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class EvolutionService {
   private readonly baseUrl: string;
+  private readonly logger = new Logger(EvolutionService.name);
 
   constructor(
     private readonly http: HttpService,
@@ -81,6 +82,11 @@ export class EvolutionService {
       });
       await lastValueFrom(response$);
     } catch (error) {
+      const status = error?.response?.status;
+      const message = error?.response?.data;
+      this.logger.error(
+        `Failed to configure webhooks: ${status} - ${JSON.stringify(message)}`,
+      );
       throw new HttpException(
         'Error configuring webhooks',
         HttpStatus.BAD_REQUEST,

--- a/src/webhooks/guards/evolution-api-webhook.guard.ts
+++ b/src/webhooks/guards/evolution-api-webhook.guard.ts
@@ -1,5 +1,5 @@
 // src/webhooks/guards/evolution-api-webhook.guard.ts
-import { CanActivate, ExecutionContext, Injectable, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException, ForbiddenException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
@@ -8,6 +8,8 @@ export class EvolutionApiWebhookGuard implements CanActivate {
   constructor(
     private readonly configService: ConfigService,
   ) {}
+
+  private readonly logger = new Logger(EvolutionApiWebhookGuard.name);
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
@@ -21,6 +23,7 @@ export class EvolutionApiWebhookGuard implements CanActivate {
 
     // Compara el token de la petición con el secreto del servidor.
     if (token !== secret) {
+      this.logger.warn('Webhook token mismatch');
       throw new UnauthorizedException('Invalid webhook token.');
     }
 


### PR DESCRIPTION
## Summary
- log when configureWebhooks fails
- warn on webhook token mismatch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b475b7a148322b344ad7762580ccc