### PR TITLE
Document webhook secret

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -3,6 +3,23 @@
 ## Introducción
 WLink Bridge es un servicio que conecta Evolution API con GoHighLevel. La integración requiere diversas variables de entorno, incluida `EVOLUTION_CONSOLE_URL` para apuntar a la consola de Evolution y `EVOLUTION_WEBHOOK_SECRET` para proteger los webhooks entrantes. Consulta `.env.example` para ver la lista completa de variables.
 
+## Secreto del Webhook
+
+La variable `EVOLUTION_WEBHOOK_SECRET` debe coincidir con el secreto configurado para tu webhook en la consola de Evolution. Este valor se utiliza para verificar que las solicitudes de webhook provienen realmente de Evolution.
+
+Ejemplo de configuración:
+
+```dotenv
+# .env
+EVOLUTION_WEBHOOK_SECRET="mi-secreto-webhook"
+```
+
+En la configuración de Evolution API define el mismo valor para el secreto del webhook:
+
+```text
+Webhook secret: mi-secreto-webhook
+```
+
 Todas las IDs de instancia se almacenan como cadenas para adecuarse al esquema de Prisma. Las funciones auxiliares convierten los identificadores numéricos en cadenas antes de las consultas a la base de datos. Al conectar una nueva instancia de Evolution es necesario proporcionar el `instanceId` junto con el token de API. El servicio valida estas credenciales antes de guardarlas.
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This service acts as a bridge between Evolution API and GoHighLevel. The integration requires several environment variables, including `EVOLUTION_CONSOLE_URL` to point to the Evolution API console and `EVOLUTION_WEBHOOK_SECRET` to secure incoming webhooks. See `.env.example` for the complete list.
 
+## Webhook Secret
+
+`EVOLUTION_WEBHOOK_SECRET` must match the secret configured for your webhook in the Evolution console. This value is used to verify that webhook requests truly originate from Evolution.
+
+Example configuration:
+
+```dotenv
+# .env
+EVOLUTION_WEBHOOK_SECRET="my-webhook-secret"
+```
+
+In Evolution API settings, configure the webhook secret to the same value:
+
+```text
+Webhook secret: my-webhook-secret
+```
+
 
 All instance IDs are stored as strings to match the Prisma schema. Helper
 functions convert any numeric IDs to strings before database queries are


### PR DESCRIPTION
## Summary
- document matching `EVOLUTION_WEBHOOK_SECRET` for Evolution API
- provide example usage in both English and Spanish READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b475c598c83228264146852bc6085