### PR TITLE
Update Evolution API webhook guard tests

### DIFF
--- a/src/webhooks/guards/evolution-api-webhook.guard.spec.ts
+++ b/src/webhooks/guards/evolution-api-webhook.guard.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
 import { EvolutionApiWebhookGuard } from './evolution-api-webhook.guard';
 import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
@@ -8,7 +8,7 @@ describe('EvolutionApiWebhookGuard', () => {
   let configService: ConfigService;
 
   beforeEach(() => {
-    configService = { get: jest.fn().mockReturnValue('secret') } as any;
+    configService = { get: jest.fn().mockReturnValue('token-secreto-de-prueba') } as any;
     guard = new EvolutionApiWebhookGuard(configService);
   });
 
@@ -16,18 +16,18 @@ describe('EvolutionApiWebhookGuard', () => {
     switchToHttp: () => ({ getRequest: () => request as Request }),
   } as any);
 
-  it('allows token in headers', async () => {
-    const ctx = createContext({ headers: { 'x-evolution-token': 'secret' } as any });
+  it('debería permitir el acceso si el header "x-evolution-token" es válido', async () => {
+    const ctx = createContext({ headers: { 'x-evolution-token': 'token-secreto-de-prueba' } as any });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
-  it('allows token in query', async () => {
-    const ctx = createContext({ headers: {}, query: { token: 'secret' } as any, body: {} });
-    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  it('debería lanzar UnauthorizedException si el token falta en el header', async () => {
+    const ctx = createContext({ headers: {} });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 
-  it('allows token in body', async () => {
-    const ctx = createContext({ headers: {}, query: {}, body: { webhook_token: 'secret' } });
-    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+  it('debería lanzar UnauthorizedException si el token en el header es incorrecto', async () => {
+    const ctx = createContext({ headers: { 'x-evolution-token': 'token-incorrecto' } as any });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 });


### PR DESCRIPTION
## Summary
- update the EvolutionApiWebhookGuard tests to match the implementation

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_687bc4a4131c8322899db90e61973ee9