### PR TITLE
Fix lock file sync issue

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.1.5",
+        "@nestjs/serve-static": "^5.0.0",
         "@nestjs/throttler": "^6.4.0",
         "@prisma/client": "6.11.1",
         "axios": "^1.11.0",
@@ -1970,6 +1971,33 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-5.0.3.tgz",
+      "integrity": "sha512-0jFjTlSVSLrI+mot8lfm+h2laXtKzCvgsVStv9T1ZBZTDwS26gM5czIhIESmWAod0PfrbCDFiu9C1MglObL8VA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-to-regexp": "8.2.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.4",
+        "@nestjs/common": "^11.0.2",
+        "@nestjs/core": "^11.0.2",
+        "express": "^5.0.1",
+        "fastify": "^5.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {


### PR DESCRIPTION
## Summary
- install @nestjs/serve-static with npm to regenerate `package-lock.json`

## Testing
- `npm test` *(fails: this.prisma.getInstance is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_688d3efe8a1083228ec61533068b4ed3