### PR TITLE
Align API path and request field

### DIFF
--- a/backend/src/custom-page/custom-page.controller.tsx
+++ b/backend/src/custom-page/custom-page.controller.tsx
@@ -13,7 +13,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { ConfigService } from '@nestjs/config'; // Importa ConfigService para acceder a variables de entorno
 import * as CryptoJS from 'crypto-js'; // Importa CryptoJS para la desencriptación
 
-@Controller('app') // El controlador está mapeado a la ruta base /app
+@Controller('api') // El controlador está mapeado a la ruta base /api
 export class CustomPageController {
   constructor(
     private readonly logger: Logger, // Servicio para logging
@@ -21,7 +21,7 @@ export class CustomPageController {
     private readonly configService: ConfigService, // Servicio para acceder a la configuración y variables de entorno
   ) {}
 
-  @Post('decrypt-user-data') // Este método maneja las peticiones POST a /app/decrypt-user-data
+  @Post('decrypt-user-data') // Maneja las peticiones POST a /api/decrypt-user-data
   @HttpCode(HttpStatus.OK) // Devuelve un código de estado 200 OK si todo va bien
   async decryptUserData(
     @Body() body: { encryptedData: string }, // Espera un cuerpo de petición con la propiedad 'encryptedData'

--- a/backend/src/evolution-api/evolution-api.service.spec.ts
+++ b/backend/src/evolution-api/evolution-api.service.spec.ts
@@ -14,6 +14,7 @@ describe('createEvolutionApiInstanceForUser', () => {
   beforeEach(() => {
     prisma = {
       getInstanceByNameAndToken: jest.fn().mockResolvedValue(null),
+      getInstance: jest.fn().mockResolvedValue(null),
       createInstance: jest.fn(),
     } as Partial<PrismaService>;
     evo = {

--- a/frontend/src/app/custom-page/page.tsx
+++ b/frontend/src/app/custom-page/page.tsx
@@ -156,7 +156,7 @@ function CustomPageContent() {
       // CORREGIDO: Usar '/api/decrypt-user-data' para coincidir con la configuración de Nginx.
       const res: DecryptResponse = await makeApiRequest('/api/decrypt-user-data', {
         method: 'POST',
-        body: JSON.stringify({ data: encData }),
+        body: JSON.stringify({ encryptedData: encData }),
       });
       if (res.success && res.locationId && res.userData) {
         setEncrypted(encData);


### PR DESCRIPTION
## Summary
- align controller route to `/api`
- update frontend to send `encryptedData` instead of `data`
- fix test mocks to include `getInstance` for Evolution API service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d651ae2f48322a2c71bcad4c3a8d0