### PR TITLE
Investigate and resolve persistent issue

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,7 +69,6 @@ http {
 
         # 3. Peticiones para la aplicación Next.js - Manejar oauth-success específicamente
         location /app/oauth-success {
-            rewrite ^/app(/.*)$ $1 break;
             proxy_pass http://frontend_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -82,7 +81,6 @@ http {
 
         # 4. Peticiones para la aplicación Next.js - General
         location /app/ {
-            rewrite ^/app(/.*)$ $1 break;
             proxy_pass http://frontend_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Remove Nginx rewrite rules for `/app` paths to fix an infinite redirect loop.

The Nginx `rewrite` directives were stripping the `/app` prefix from incoming requests, which conflicted with the Next.js frontend's `basePath: '/app'` configuration, causing a continuous redirect loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a163fec-f237-4dfc-81be-60b29f0362a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a163fec-f237-4dfc-81be-60b29f0362a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

