### PR TITLE
Analizar y solucionar problemas del repositorio

### DIFF
--- a/OAUTH_SETUP.md
+++ b/OAUTH_SETUP.md
@@ -7,11 +7,11 @@
 - El callback OAuth no funciona correctamente
 
 ### Causa
-El problema principal era la falta de la variable de entorno `FRONTEND_URL` en la configuración del backend, lo que causaba que el controlador OAuth no pudiera redirigir correctamente a la página de éxito.
+El problema principal era la falta de la variable de entorno `FRONTEND_URL` en la configuración del backend, junto con una configuración de Nginx que eliminaba el prefijo `/app` al reenviar al frontend, lo que generaba bucles de redirección.
 
 ### Solución Implementada
 
-1. **Agregada variable FRONTEND_URL al docker-compose.yml**:
+1. **Agregada variable FRONTEND_URL al entorno**:
    ```yaml
    environment:
      - FRONTEND_URL=${FRONTEND_URL}
@@ -20,6 +20,9 @@ El problema principal era la falta de la variable de entorno `FRONTEND_URL` en l
 2. **Mejorado el controlador OAuth** para manejar el caso donde `FRONTEND_URL` no esté definida:
    - Ahora usa `APP_URL/app` como fallback
    - Registra un warning en lugar de lanzar una excepción
+
+3. **Nginx ajustado** para preservar el prefijo `/app`:
+   - `proxy_pass http://frontend_service;` (sin barra final) dentro de `location /app/ { ... }`
 
 ### Variables de Entorno Requeridas
 
@@ -55,7 +58,7 @@ https://tu-dominio.com/oauth/callback
 
 El nginx.conf ya está configurado correctamente para manejar:
 - `/oauth/*` → Backend (puerto 3000)
-- `/app/*` → Frontend (puerto 3001)
+- `/app/*` → Frontend (puerto 3001) con `proxy_pass` sin barra final
 
 ### Troubleshooting
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,7 +73,8 @@ http {
 
         # 3. Frontend Next.js - TODO bajo /app/
         location /app/ {
-            proxy_pass http://frontend_service/;
+            # Importante: sin la barra final para preservar el prefijo /app
+            proxy_pass http://frontend_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -89,6 +90,7 @@ http {
         }
 
         # 4. Redirige /app sin slash a /app/ SOLO si no hay más path
+        # 4. Redirección única de /app a /app/
         location = /app {
             return 301 /app/;
         }


### PR DESCRIPTION
Fix Nginx proxy configuration for `/app` to resolve redirect loops in the OAuth callback.

The previous Nginx configuration for `/app` was removing the prefix when proxying to the frontend, which caused `ERR_TOO_MANY_REDIRECTS` when combined with Next.js `basePath`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a12e1f3c-20b3-4722-920d-3a1ce955a693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a12e1f3c-20b3-4722-920d-3a1ce955a693">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

