### PR TITLE
Fix Nginx basePath rewrite for Next.js

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -73,8 +73,11 @@ http {
 
         # 3. Frontend Next.js - TODO bajo /app/
         location /app/ {
-            # Importante: sin la barra final para preservar el prefijo /app
+            # CORRECCIÓN: Reescribe la URL eliminando el prefijo /app
+            # para que Next.js reciba la ruta correcta sin el basePath.
+            rewrite ^/app(/.*)$ $1 break;
             proxy_pass http://frontend_service;
+            
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- rewrite `/app` requests before proxying to Next.js so it receives paths without the basePath

## Testing
- `nginx -t -c /workspace/WLink/nginx/nginx.conf` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68968cf9a27483228bc4ddc0e3196477